### PR TITLE
Add WITH SYSTEM_MODE to fflib_AppBindingsSelector class

### DIFF
--- a/sfdx-source/apex-extensions/main/application/dynamic/classes/fflib_AppBindingsSelector.cls
+++ b/sfdx-source/apex-extensions/main/application/dynamic/classes/fflib_AppBindingsSelector.cls
@@ -48,7 +48,8 @@ public virtual without sharing class fflib_AppBindingsSelector extends fflib_SOb
   }
 
   public static fflib_AppBindingsSelector newInstance() {
-    return (fflib_AppBindingsSelector) SELECTOR_IMPL_TYPE.newInstance();
+    return (fflib_AppBindingsSelector) ((fflib_AppBindingsSelector) SELECTOR_IMPL_TYPE.newInstance())
+      .setDataAccess(fflib_SObjectSelector.DataAccess.SYSTEM_MODE);
   }
 
   public Schema.SObjectType getSObjectType() {


### PR DESCRIPTION
This should avoid the requirement of adding read permission to the custom medata object. Particular for external users